### PR TITLE
Prepare 16-SNAPSHOT and 13-SNAPSHOT

### DIFF
--- a/src/java/tring/pom.xml
+++ b/src/java/tring/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.privacyresearch</groupId>
     <artifactId>tring</artifactId>
-    <version>0.0.15</version>
+    <version>0.0.16-SNAPSHOT</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/java/tringapi/pom.xml
+++ b/src/java/tringapi/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.privacyresearch</groupId>
     <artifactId>tringapi</artifactId>
-    <version>0.0.12</version>
+    <version>0.0.13-SNAPSHOT</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Note: we don't automatically bump the dependency on tring-api to 13-SNAPSHOT, as tring-api might be unchanged while tring changes