### PR TITLE
Fix macos-x64 build

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ ubuntu-20.04, macos-latest, macos-14, windows-latest ]
+        os: [ ubuntu-20.04, macos-latest, macos-13, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
`macos-latest` is now pointed to `macos-14` which is `aarch64` based.