### PR TITLE
Improve java rust ffi protocol

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,8 +93,13 @@ java:
 		echo "java: Preparing workspace for $(PLATFORM)" ; \
 		./bin/prepare-workspace $(PLATFORM) ; \
 	fi
-	echo "java: Release build" ; \
-	./bin/build-java -r --ringrtc-only
+	$(Q) if [ "$(TYPE)" = "release" ] ; then \
+		echo "java: Release build" ; \
+		./bin/build-java -r --ringrtc-only; \
+	else \
+		echo "java: Debug build" ; \
+		./bin/build-java -d --ringrtc-only; \
+	fi
 
 cli:
 	$(Q) if [ "$(PLATFORM)" != "" ] ; then \

--- a/bin/build-java
+++ b/bin/build-java
@@ -184,13 +184,13 @@ fi
         mkdir -p ../java/build/win32
         cp -f ../../target/${CARGO_TARGET}/${BUILD_TYPE}/ringrtc.dll ../java/tring/src/main/resources/ringrtc.dll
         # cp -f ../../target/${CARGO_TARGET}/${BUILD_TYPE}/ringrtc.dll ../java/build/win32/libringrtc-"${TARGET_ARCH}".java
-        ${JEXTRACT}/bin/jextract -I${JDK}include -I${JDK}/include/win32 --output ../java/tring/src/main/java -t io.privacyresearch.tring tringlib.h
+        ${JEXTRACT}/bin/jextract -I${JDK}include -I${JDK}/include/win32 --output ../java/tring/src/gen-sources/java -t io.privacyresearch.tring tringlib.h
     elif [ $DEFAULT_PLATFORM = "linux" ]
     then
         mkdir -p ../java/build/linux
         cp -f ../../target/${CARGO_TARGET}/${BUILD_TYPE}/libringrtc.so ../java/tring/src/main/resources/libringrtc.so
         #cp -f target/${CARGO_TARGET}/${BUILD_TYPE}/libringrtc.so ../java/build/linux/libringrtc-"${TARGET_ARCH}".java
-        ${JEXTRACT}/bin/jextract -I${JDK}include -I${JDK}/include/linux --output ../java/tring/src/main/java -t io.privacyresearch.tring tringlib.h
+        ${JEXTRACT}/bin/jextract -I${JDK}include -I${JDK}/include/linux --output ../java/tring/src/gen-sources/java -t io.privacyresearch.tring tringlib.h
     fi
     cd ../java/tringapi
     mvn clean install

--- a/bin/build-java
+++ b/bin/build-java
@@ -165,7 +165,7 @@ fi
     echo "Build final RingRTC"
     if [ "${BUILD_TYPE}" = "debug" ]
     then
-        RUSTFLAGS="${RUSTFLAGS_WIN}" OUTPUT_DIR="${OUTPUT_DIR}" cargo build --target ${CARGO_TARGET} --features java
+        RUSTFLAGS="${RUSTFLAGS_WIN}" OUTPUT_DIR="${OUTPUT_DIR}" cargo rustc --package ringrtc --target ${CARGO_TARGET} --features java --crate-type cdylib
     else
         #OUTPUT_DIR="${OUTPUT_DIR}" cargo build --target ${CARGO_TARGET} --lib --features java --release
         RUSTFLAGS="${RUSTFLAGS}" OUTPUT_DIR="${OUTPUT_DIR}" cargo rustc --package ringrtc --target ${CARGO_TARGET} --features java --release --crate-type cdylib

--- a/src/java/tring/pom.xml
+++ b/src/java/tring/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.privacyresearch</groupId>
     <artifactId>tring</artifactId>
-    <version>0.0.21</version>
+    <version>0.0.22-SNAPSHOT</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>io.privacyresearch</groupId>
             <artifactId>tringapi</artifactId>
-            <version>0.0.16</version>
+            <version>0.0.17-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/src/java/tring/src/main/java/io/privacyresearch/tring/TringAppInterface.java
+++ b/src/java/tring/src/main/java/io/privacyresearch/tring/TringAppInterface.java
@@ -1,0 +1,166 @@
+package io.privacyresearch.tring;
+
+import io.privacyresearch.tringapi.TringApi;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Logger;
+
+public class TringAppInterface {
+
+    private static final Logger LOG = Logger.getLogger(TringAppInterface.class.getName());
+
+    private final TringExecutorService executorService;
+    private final TringApi tringApi;
+    private final Arena scope;
+
+    private long nativeCallEndpoint;
+
+    private int clientId = -1;
+    private byte[] localGroupId;
+    private long activeCallId;
+
+    public TringAppInterface(TringExecutorService executorService, TringApi tringApi, Arena scope) {
+        this.executorService = executorService;
+        this.tringApi = tringApi;
+        this.scope = scope;
+    }
+
+    public void setNativeCallEndpoint(long nativeCallEndpoint) {
+        LOG.info("[TringAppInterface::setNativeCallEndpoint] nativeCallEndpoint=" + nativeCallEndpoint);
+
+        this.nativeCallEndpoint = nativeCallEndpoint;
+    }
+
+    public void setLocalGroupId(byte[] localGroupId) {
+        this.localGroupId = localGroupId;
+    }
+
+    public byte[] getLocalGroupId() {
+        return localGroupId;
+    }
+
+    public void setClientId(int clientId) {
+        this.clientId = clientId;
+    }
+
+    public void setActiveCallId(long activeCallId) {
+        this.activeCallId = activeCallId;
+    }
+
+    public long getActiveCallId() {
+        return activeCallId;
+    }
+
+    public void destroy() {
+        LOG.info("[TringAppInterface::destroy]");
+    }
+
+    public void groupConnectionStateChanged(int clientId, int connectionState) {
+        LOG.info("[TringAppInterface::groupConnectionStateChanged] clientId=" + clientId + ", connectionState=" + connectionState);
+    }
+
+    public void groupEnded(int clientId, int reason) {
+        LOG.info("[TringAppInterface::groupEnded] clientId=" + clientId + ", reason=" + reason);
+
+        tringlib_h.deleteGroupCallClient(nativeCallEndpoint, clientId);
+        this.clientId = -1;
+    }
+
+    public void groupJoinStateChanged(int clientId, int joinState) {
+        LOG.info("[TringAppInterface::groupJoinStateChanged] clientId=" + clientId + ", joinState=" + joinState);
+
+        if (joinState == 3) {
+            LOG.info("We joined, now do a group call ring");
+            tringlib_h.group_ring(nativeCallEndpoint, 1);
+        }
+    }
+
+    public void groupRequestGroupMembers(int clientId) {
+        LOG.info("[TringAppInterface::groupRequestGroupMembers] clientId=" + clientId);
+        byte[] groupMemberInfo = tringApi.requestGroupMemberInfo(localGroupId);
+        tringlib_h.setGroupMembers(nativeCallEndpoint, clientId, TringServiceImpl.toJByteArray(scope, groupMemberInfo));
+    }
+
+    public void groupRequestMembershipProof(int clientId) {
+        LOG.info("[TringAppInterface::groupRequestMembershipProof] clientId=" + clientId);
+
+        executorService.executeRequest(() -> {
+            LOG.info("Requesting membership proof, groupid = " + Arrays.toString(TringAppInterface.this.localGroupId));
+            byte[] groupMembershipToken = tringApi.requestGroupMembershipToken(TringAppInterface.this.localGroupId);
+            tringlib_h.setMembershipProof(nativeCallEndpoint, clientId, TringServiceImpl.toJByteArray(scope, groupMembershipToken));
+        });
+    }
+
+    public void groupRing(MemorySegment groupId, long ringId, MemorySegment senderId, int update) {
+        byte[] bGroupId = TringServiceImpl.fromJArrayByte(groupId);
+        byte[] bSenderId = TringServiceImpl.fromJArrayByte(senderId);
+
+        LOG.info("[TringAppInterface::groupRing] groupId=" + Arrays.toString(bGroupId) + ", ringId=" + ringId + ", senderId=" + Arrays.toString(bSenderId) + ", update=" + update);
+
+        this.localGroupId = bGroupId;
+        tringApi.groupCallUpdateRing(bGroupId, ringId, bSenderId, update);
+    }
+
+    public void sendCallMessage(MemorySegment recipient, MemorySegment message, int urgency) {
+        byte[] bRecipient = TringServiceImpl.fromJArrayByte(recipient);
+        byte[] bMessage = TringServiceImpl.fromJArrayByte(message);
+
+        LOG.info("[TringAppInterface::sendCallMessage] recipient=" + Arrays.toString(bRecipient) + ", urgency=" + urgency);
+
+        tringApi.sendOpaqueCallMessage(bRecipient, bMessage, urgency);
+    }
+
+    public void sendCallMessageToGroup(MemorySegment groupId, MemorySegment message, int urgency) {
+        byte[] bGroupId = TringServiceImpl.fromJArrayByte(groupId);
+        byte[] bMessage = TringServiceImpl.fromJArrayByte(message);
+
+        LOG.info("[TringAppInterface::sendCallMessageToGroup] groupId=" + Arrays.toString(bGroupId) + ", urgency=" + urgency);
+
+        tringApi.sendOpaqueGroupCallMessage(bGroupId, bMessage, urgency);
+    }
+
+    public void signalingMessageAnswer(MemorySegment answer) {
+        byte[] bAnswer = TringServiceImpl.fromJArrayByte(answer);
+
+        LOG.info("[TringAppInterface::signalingMessageAnswer] answer=" + Arrays.toString(bAnswer));
+
+        tringApi.answerCallback(bAnswer);
+
+        acknowledgeSignalingMessageSent();
+    }
+
+    public void signalingMessageIce(MemorySegment ice) {
+        byte[] bIce = TringServiceImpl.fromJArrayByte(ice);
+
+        LOG.info("[TringAppInterface::signalingMessageIce] ice=" + Arrays.toString(bIce));
+
+        tringApi.iceUpdateCallback(List.of(bIce));
+
+        acknowledgeSignalingMessageSent();
+    }
+
+    public void signalingMessageOffer(MemorySegment offer) {
+        byte[] bOffer = TringServiceImpl.fromJArrayByte(offer);
+
+        LOG.info("[TringAppInterface::signalingMessageOffer] offer=" + Arrays.toString(bOffer));
+
+        tringApi.offerCallback(bOffer);
+
+        acknowledgeSignalingMessageSent();
+    }
+
+    // We need to inform ringrtc that we handled a message, so that it is ok
+    // with sending the next message
+    public void acknowledgeSignalingMessageSent() {
+        LOG.info("Acknowledging signaling message sent");
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment callId = arena.allocateFrom(ValueLayout.JAVA_LONG, activeCallId);
+            tringlib_h.signalMessageSent(nativeCallEndpoint, callId);
+        }
+        LOG.info("Acknowledging signaling message sent complete");
+    }
+}

--- a/src/java/tring/src/main/java/io/privacyresearch/tring/TringExecutorService.java
+++ b/src/java/tring/src/main/java/io/privacyresearch/tring/TringExecutorService.java
@@ -1,0 +1,20 @@
+package io.privacyresearch.tring;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class TringExecutorService {
+
+    private static final Logger LOG = Logger.getLogger(TringExecutorService.class.getName());
+
+    private final ExecutorService executor = Executors.newFixedThreadPool(1);
+
+    public void executeRequest(Runnable runnable) {
+        LOG.info("Executing request "+runnable);
+        Future<?> submit = executor.submit(runnable);
+        LOG.info("Execution state = " + submit.state());
+    }
+}

--- a/src/java/tringapi/pom.xml
+++ b/src/java/tringapi/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.privacyresearch</groupId>
     <artifactId>tringapi</artifactId>
-    <version>0.0.16</version>
+    <version>0.0.17-SNAPSHOT</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/java/tringapi/src/main/java/io/privacyresearch/tringapi/TringApi.java
+++ b/src/java/tringapi/src/main/java/io/privacyresearch/tringapi/TringApi.java
@@ -17,7 +17,7 @@ public interface TringApi {
 
     void iceUpdateCallback(List<byte[]> iceCandidates);
 
-    void groupCallUpdateRing(byte[] groupId, long ringId, byte[] senderBytes, byte status);
+    void groupCallUpdateRing(byte[] groupId, long ringId, byte[] senderBytes, int status);
     // void getVideoFrame(int w, int h, byte[] raw);
 
     public void receivedGroupCallPeekForRingingCheck(PeekInfo peekInfo);
@@ -28,8 +28,8 @@ public interface TringApi {
 
     public void sendOpaqueGroupCallMessage(byte[] groupIdentifier, byte[] opaque, int urgency);
 
-    public void sendOpaqueCallMessage(UUID recipient, byte[] opaque, int urgency);
+    public void sendOpaqueCallMessage(byte[] recipientIdentifier, byte[] opaque, int urgency);
 
-    public void updateRemoteDevices(List<Integer> demuxIds);
+    public void updateRemoteDevices(List<Long> demuxIds);
 
 }

--- a/src/java/tringapi/src/main/java/io/privacyresearch/tringapi/TringBridge.java
+++ b/src/java/tringapi/src/main/java/io/privacyresearch/tringapi/TringBridge.java
@@ -89,7 +89,7 @@ public class TringBridge {
         service.enableOutgoingVideo(enable);
     }
 
-    public TringFrame getRemoteVideoFrame(int demuxId) {
+    public TringFrame getRemoteVideoFrame(long demuxId) {
         return service.getRemoteVideoFrame(demuxId);
     }  
 
@@ -105,7 +105,7 @@ public class TringBridge {
         service.peekGroupCall(membershipProof, members);
     }
 
-    public long createGroupCallClient(byte[] groupId, String sfu, byte[] hkdf) {
+    public int createGroupCallClient(byte[] groupId, String sfu, byte[] hkdf) {
         return service.createGroupCallClient(groupId, sfu, hkdf);
     }
 

--- a/src/java/tringapi/src/main/java/io/privacyresearch/tringapi/TringService.java
+++ b/src/java/tringapi/src/main/java/io/privacyresearch/tringapi/TringService.java
@@ -54,9 +54,9 @@ public interface TringService {
      * @param skip if true, ignore all old frames, and return the most recent one
      * @return a frame
      */
-    public TringFrame getRemoteVideoFrame(int demuxId, boolean skip);
+    public TringFrame getRemoteVideoFrame(long demuxId, boolean skip);
 
-    public default TringFrame getRemoteVideoFrame(int demuxId) {
+    public default TringFrame getRemoteVideoFrame(long demuxId) {
         return getRemoteVideoFrame(demuxId, false);
     }
     public void sendVideoFrame(int w, int h, int pixelFormat, byte[] raw);
@@ -65,7 +65,7 @@ public interface TringService {
 
     public void peekGroupCall(byte[] membershipProof, byte[] members);
 
-    public long createGroupCallClient(byte[] groupId, String sfu, byte[] hkdf);
+    public int createGroupCallClient(byte[] groupId, String sfu, byte[] hkdf);
 
     public void joinGroupCall();
 

--- a/src/rust/src/java/app_interface.rs
+++ b/src/rust/src/java/app_interface.rs
@@ -1,0 +1,44 @@
+use crate::{
+    core::{
+        group_call::{ClientId, EndReason},
+    },
+    java::{
+        jtypes::JArrayByte,
+    },
+};
+
+#[repr(C)]
+#[derive(Clone, Debug)]
+#[allow(non_snake_case)]
+pub struct AppInterface {
+    /// Java object clean up method.
+    pub destroy: extern "C" fn(),
+
+    pub groupConnectionStateChanged: extern "C" fn(clientId: ClientId, connection_state: i32),
+    pub groupEnded: extern "C" fn(clientId: ClientId, reason: EndReason),
+    pub groupJoinStateChanged: extern "C" fn(clientId: ClientId, join_state: i32),
+    pub groupRequestGroupMembers: extern "C" fn(clientId: ClientId),
+    pub groupRequestMembershipProof: extern "C" fn(clientId: ClientId),
+    pub groupRing: extern "C" fn(groupId: JArrayByte, ringId: i64, senderId: JArrayByte, update: i32),
+
+    pub sendCallMessage: extern "C" fn(recipient: JArrayByte, message: JArrayByte, urgency: i32),
+    pub sendCallMessageToGroup: extern "C" fn(groupId: JArrayByte, message: JArrayByte, urgency: i32),
+
+    pub signalingMessageAnswer: extern "C" fn(answer: JArrayByte),
+    pub signalingMessageIce: extern "C" fn(ice: JArrayByte),
+    pub signalingMessageOffer: extern "C" fn(offer: JArrayByte),
+}
+
+// Add an empty Send trait to allow transfer of ownership between threads.
+unsafe impl Send for AppInterface {}
+
+// Add an empty Sync trait to allow access from multiple threads.
+unsafe impl Sync for AppInterface {}
+
+// Rust owns the interface object from Java. Drop it when it goes out
+// of scope.
+impl Drop for AppInterface {
+    fn drop(&mut self) {
+        (self.destroy)();
+    }
+}

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -89,6 +89,7 @@ pub mod native;
 
 #[cfg(feature = "java")]
 pub mod java {
+    mod app_interface;
     mod java;
     mod jtypes;
 }


### PR DESCRIPTION
Introduces a class that represents the FFI application interface between java and rust. In short, this removes the need for many callbacks to be passed from java to rust, by replacing it with a single interface that implements each method. The answer, offer, ice updates and generic callbacks have been replaced with the RingAppInterface class.